### PR TITLE
chore: Remove old comment

### DIFF
--- a/tokio/src/runtime/park.rs
+++ b/tokio/src/runtime/park.rs
@@ -272,7 +272,6 @@ impl CachedParkThread {
         use std::task::Context;
         use std::task::Poll::Ready;
 
-        // `get_unpark()` should not return a Result
         let waker = self.waker()?;
         let mut cx = Context::from_waker(&waker);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

Maybe `get_unpark()` doesn't exist in tokio anymore?
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->