### PR TITLE
task: Add `TaskLocalFuture::take_value` method to the `task_local`

### DIFF
--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -336,34 +336,13 @@ impl<T, F> TaskLocalFuture<T, F>
 where
     T: 'static,
 {
-    /// Takes the task local value `T` owned by the `TaskLocalFuture`. If the
-    /// task local value exists, then returns `Some(T)` and the task local value
-    /// inside the `TaskLocalFuture` becomes unset. If it does not exist,
-    /// it returns `None`.
+    /// Returns the value stored in the task local by this `TaskLocalFuture`.
     ///
-    /// # Examples
+    /// The function returns:
     ///
-    /// ```
-    /// # async fn dox() {
-    ///  tokio::task_local! {
-    ///     static KEY: u32;
-    ///  }
-    ///
-    ///  let fut = KEY.scope(42, async {
-    ///     // Do some async work
-    ///  });
-    ///
-    ///  let mut pinned = Box::pin(fut);
-    ///
-    ///  // Complete the TaskLocalFuture
-    ///  let _ = (&mut pinned).as_mut().await;
-    ///
-    ///  // And here, we can take task local value
-    ///  let value = pinned.as_mut().take_value();
-    ///
-    ///  assert_eq!(value, Some(42));
-    /// # }
-    /// ```
+    /// * `Some(T)` if the task local value exists, and unset the task local value
+    ///   in the Future.
+    /// * `None` if the task local value does not exist.
     ///
     /// # Note
     ///
@@ -393,7 +372,31 @@ where
     /// assert_eq!(pinned.as_mut().take_value(), Some(42));
     ///
     /// // Poll **after** invoking `take_value()`
-    /// let _ = (&mut pinned).as_mut().await;
+    /// let _ = pinned.as_mut().await;
+    /// # }
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # async fn dox() {
+    /// tokio::task_local! {
+    ///     static KEY: u32;
+    /// }
+    ///
+    /// let fut = KEY.scope(42, async {
+    ///     // Do some async work
+    /// });
+    ///
+    /// let mut pinned = Box::pin(fut);
+    ///
+    /// // Complete the TaskLocalFuture
+    /// let _ = pinned.as_mut().await;
+    ///
+    /// // And here, we can take task local value
+    /// let value = pinned.as_mut().take_value();
+    ///
+    /// assert_eq!(value, Some(42));
     /// # }
     /// ```
     pub fn take_value(self: Pin<&mut Self>) -> Option<T> {

--- a/tokio/tests/task_local.rs
+++ b/tokio/tests/task_local.rs
@@ -117,3 +117,31 @@ async fn task_local_available_on_completion_drop() {
     assert_eq!(rx.await.unwrap(), 42);
     h.await.unwrap();
 }
+
+#[tokio::test]
+async fn take_value() {
+    tokio::task_local! {
+        static KEY: u32
+    }
+    let fut = KEY.scope(1, async {});
+    let mut pinned = Box::pin(fut);
+    assert_eq!(pinned.as_mut().take_value(), Some(1));
+    assert_eq!(pinned.as_mut().take_value(), None);
+}
+
+#[tokio::test]
+async fn poll_after_take_value_should_fail() {
+    tokio::task_local! {
+        static KEY: u32
+    }
+    let fut = KEY.scope(1, async {
+        let result = KEY.try_with(|_| {});
+        // The task local value no longer exists.
+        assert!(result.is_err());
+    });
+    let mut fut = Box::pin(fut);
+    fut.as_mut().take_value();
+
+    // Poll the future after `take_value` has been called
+    fut.await;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Try to resolve #.
This PR adds a method `take_value` to take the task local value of a `TaskLocalFuture`.
The `LocalKey::scope` function owns the slot value and drops it, but this method will allow you to re-acquire ownership of the slot value.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Implemented method `take_value` for a pinned `TaskLocalFuture`.
Maybe it is possible to provide non-pinned api as well (`pub fn take_value(&mut self) -> Option<T>`), but I'm not sure if it is worth providing both.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
