### PR TITLE
global_queue_interval

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -758,6 +758,10 @@ impl Builder {
     ///
     /// [the module documentation]: crate::runtime#multi-threaded-runtime-behavior-at-the-time-of-writing
     ///
+    /// # Panics
+    ///
+    /// This function will panic if 0 is passed as an argument.
+    ///
     /// # Examples
     ///
     /// ```
@@ -769,6 +773,7 @@ impl Builder {
     /// # }
     /// ```
     pub fn global_queue_interval(&mut self, val: u32) -> &mut Self {
+        assert!(val > 0, "global_queue_interval must be greater than 0");
         self.global_queue_interval = Some(val);
         self
     }

--- a/tokio/src/runtime/scheduler/multi_thread/stats.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/stats.rs
@@ -63,7 +63,7 @@ impl Stats {
         let tasks_per_interval = (TARGET_GLOBAL_QUEUE_INTERVAL / self.task_poll_time_ewma) as u32;
 
         cmp::max(
-            // We don't want to return less than 2 as that would result in the
+            // If we are using self-tuning, we don't want to return less than 2 as that would result in the
             // global queue always getting checked first.
             2,
             cmp::min(

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -985,8 +985,6 @@ impl Core {
             .stats
             .tuned_global_queue_interval(&worker.handle.shared.config);
 
-        debug_assert!(next > 1);
-
         // Smooth out jitter
         if abs_diff(self.global_queue_interval, next) > 2 {
             self.global_queue_interval = next;

--- a/tokio/src/runtime/scheduler/multi_thread_alt/stats.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/stats.rs
@@ -82,7 +82,7 @@ impl Stats {
         let tasks_per_interval = (TARGET_GLOBAL_QUEUE_INTERVAL / self.task_poll_time_ewma) as u32;
 
         cmp::max(
-            // We don't want to return less than 2 as that would result in the
+            // If we are using self-tuning, we don't want to return less than 2 as that would result in the
             // global queue always getting checked first.
             2,
             cmp::min(

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -1288,8 +1288,6 @@ impl Worker {
     fn tune_global_queue_interval(&mut self, cx: &Context, core: &mut Core) {
         let next = core.stats.tuned_global_queue_interval(&cx.shared().config);
 
-        debug_assert!(next > 1);
-
         // Smooth out jitter
         if abs_diff(self.global_queue_interval, next) > 2 {
             self.global_queue_interval = next;


### PR DESCRIPTION
Currently specifying 0 or 1 for `global_queue_interval` causes a panic. This PR:

- Added documentation indicating that setting `global_queue_interval` to 0 is not allowed and included an assert in the builder.
- Removed the `debug_assert!(next > 1)` that could be triggered when `global_queue_interval` is set to 1.
    - Although it's still unclear whether there is a practical benefit to always prioritize checking the global queue first, but i guess it's probably better than causing a panic in debug builds.