### PR TITLE
fix failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - x86_64-fortanix-unknown-sgx
       - check-redox
       - wasm32-unknown-unknown
-      - wasm32-wasi
+      - wasm32-wasip1
       - check-external-types
       - check-fuzzing
       - check-unstable-mt-counters
@@ -908,15 +908,15 @@ jobs:
         run: wasm-pack test --node -- --features "macros sync"
         working-directory: tokio
 
-  wasm32-wasi:
+  wasm32-wasip1:
     name: ${{ matrix.target }}
     needs: basics
     runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
-          - wasm32-wasi
-          - wasm32-wasi-preview1-threads
+          - wasm32-wasip1
+          - wasm32-wasip1-threads
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust ${{ env.rust_stable }}
@@ -956,12 +956,12 @@ jobs:
       - name: test tests-integration --features wasi-rt
         # TODO: this should become: `cargo hack wasi test --each-feature`
         run: cargo wasi test --test rt_yield --features wasi-rt
-        if: matrix.target == 'wasm32-wasi'
+        if: matrix.target == 'wasm32-wasip1'
         working-directory: tests-integration
 
       - name: test tests-integration --features wasi-threads-rt
         run: cargo test --target ${{ matrix.target }} --features wasi-threads-rt
-        if: matrix.target == 'wasm32-wasi-preview1-threads'
+        if: matrix.target == 'wasm32-wasip1-threads'
         working-directory: tests-integration
         env:
           CARGO_TARGET_WASM32_WASI_PREVIEW1_THREADS_RUNNER: "wasmtime run -W bulk-memory=y -W threads=y -S threads=y --"

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -8,6 +8,7 @@ use std::process::ExitStatus;
 /// An interface for waiting on a process to exit.
 pub(crate) trait Wait {
     /// Get the identifier for this process or diagnostics.
+    #[allow(dead_code)]
     fn id(&self) -> u32;
     /// Try waiting for a process to exit in a non-blocking manner.
     fn try_wait(&mut self) -> io::Result<Option<ExitStatus>>;

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -450,6 +450,7 @@ impl Launch {
 }
 
 fn run(worker: Arc<Worker>) {
+    #[allow(dead_code)]
     struct AbortOnPanic;
 
     impl Drop for AbortOnPanic {

--- a/tokio/src/util/markers.rs
+++ b/tokio/src/util/markers.rs
@@ -1,4 +1,5 @@
 /// Marker for types that are `Sync` but not `Send`
+#[allow(dead_code)]
 pub(crate) struct SyncNotSend(#[allow(dead_code)] *mut ());
 
 unsafe impl Sync for SyncNotSend {}


### PR DESCRIPTION
This PR
* fixes warnings introduced in 1.78.0
* changes the target name from `wasm32-wasi`, `wasm32-wasi-preview1-threads` to `wasm32-wasip1`, `wasm32-wasip1-threads`